### PR TITLE
Permit plugin designation without URL for known plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ git submodule add https://github.com/sobolevn/dotbot-asdf.git
       url: https://github.com/asdf-vm/asdf-ruby.git
 ```
 
+Plugins can also be specified with just a name for [known plugins](https://asdf-vm.com/#/plugins-all?id=plugin-list):
+
+```yaml
+# This example uses python, nodejs and ruby plugins:
+
+- asdf:
+    - plugin: python
+    - plugin: nodejs
+    - plugin: ruby
+```
+
 That's it!
 
 

--- a/asdf.py
+++ b/asdf.py
@@ -67,7 +67,6 @@ class Brew(dotbot.Plugin):
                     'Unknown plugin: {}\nPlease provide URL'.format(name)
                 )
 
-
     def _build_command(self, plugin, url):
         if not url:
             return '{} {}'.format(self._install_command, plugin)
@@ -89,4 +88,3 @@ class Brew(dotbot.Plugin):
             if output_err is not None:
                 message = 'Failed to install: ' + plugin['plugin']
                 raise ValueError(message + ' ')
-

--- a/asdf.py
+++ b/asdf.py
@@ -86,7 +86,7 @@ class Brew(dotbot.Plugin):
             p.wait()
             _, output_err = p.communicate()
 
-            if output_err != None:
+            if output_err is not None:
                 message = 'Failed to install: ' + plugin['plugin']
                 raise ValueError(message + ' ')
 

--- a/asdf.py
+++ b/asdf.py
@@ -44,19 +44,22 @@ class Brew(dotbot.Plugin):
             name = plugin.get('plugin', None)
             url = plugin.get('url', None)
 
-            if not name or not url:
+            if not name:
                 raise ValueError(
                     '{} is not valid plugin definition'.format(str(plugin))
                 )
 
 
     def _build_command(self, plugin, url):
-        return '{} {} {}'.format(self._install_command, plugin, url)
+        if not url:
+            return '{} {}'.format(self._install_command, plugin)
+        else:
+            return '{} {} {}'.format(self._install_command, plugin, url)
 
     def _handle_install(self, data):
         for plugin in data:
             p = subprocess.Popen(
-                self._build_command(plugin['plugin'], plugin['url']),
+                self._build_command(plugin['plugin'], plugin.get('url', None)),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 shell=True,

--- a/asdf.py
+++ b/asdf.py
@@ -17,6 +17,20 @@ class Brew(dotbot.Plugin):
 
     _install_command = 'asdf plugin-add'
 
+    def __init__(self, context):
+        super(Brew, self).__init__(context)
+        p = subprocess.Popen(
+            'asdf plugin-list-all',
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            shell=True,
+            cwd=self.cwd
+        )
+        p.wait()
+        output, _ = p.communicate()
+        plugins = output.decode('utf-8')
+        self._known_plugins = plugins.split()[::2]
+
     # API methods
 
     def can_handle(self, directive):
@@ -47,6 +61,10 @@ class Brew(dotbot.Plugin):
             if not name:
                 raise ValueError(
                     '{} is not valid plugin definition'.format(str(plugin))
+                )
+            elif not url and name not in self._known_plugins:
+                raise ValueError(
+                    'Unknown plugin: {}\nPlease provide URL'.format(name)
                 )
 
 


### PR DESCRIPTION
`asdf` can install many plugins without a URL (e.g. `asdf plugin-add python`). This PR allows users to install `asdf` plugins with `dotbot` without specifying a URL, provided the plugin is known to `asdf`.