### PR TITLE
(feat) Allow configuring asdf location

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ You can even install desired versions of languages and the global version:
       - 2.6.4
 ```
 
+It's also possible to configure the location for asdf in case asdf itself was
+installed as part of the dotbot install process. This will cause the plugin to
+source the provided script before every asdf command.
+
+```yaml
+- asdf:
+  - asdf_path: /opt/asdf-vm/asdf.sh
+  - plugin: python
+    global: 3.10.4
+    versions:
+      - 3.10.4
+```
+
 That's it!
 
 ## License

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ It's also possible to configure the location for asdf in case asdf itself was
 installed as part of the dotbot install process. This will cause the plugin to
 source the provided script before every asdf command.
 
+Only the first instance of `asdf_path` in the configuration will be respected.
+
 ```yaml
 - asdf:
   - asdf_path: /opt/asdf-vm/asdf.sh


### PR DESCRIPTION
Move asdf known plugins detection out of init method so the plugin won't try to call asdf as soon as the install command is initiated. This allows us to install asdf as a step in the dotbot install command before the asdf plugin is run. Since asdf won't have been sourced between install and run, I also added the ability to configure asdf so this plugin can source it itself.

I tried to maintain python 2.7 compatibility, but the plugin I use to install asdf is not python2 compatible, so I was unable to test this fully.