### PR TITLE
Adding asdf 0.16 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,16 @@ Install [`asdf`](https://github.com/asdf-vm/asdf) plugins and programming langua
 ## Prerequirements
 
 This plugin requires [`dotbot`](https://github.com/anishathalye/dotbot/) to be installed.
-
 Also, at runtime this plugin requires `asdf` command to be installed.
 
 ## Installation
 
 1. Run:
-
 ```bash
 git submodule add https://github.com/sobolevn/dotbot-asdf.git
 ```
 
 2. Modify your `./install` with new plugin directory:
-
 ```bash
 "${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" --plugin-dir dotbot-asdf -c "${CONFIG}" "${@}"
 ```
@@ -28,7 +25,6 @@ Add required options to your [`install.conf.yaml`](/example.yaml):
 
 ```yaml
 # This example uses python, nodejs and ruby plugins:
-
 - asdf:
   - plugin: python
     url: https://github.com/tuvistavie/asdf-python.git
@@ -42,52 +38,82 @@ Plugins can also be specified with just a name for [known plugins](https://asdf-
 
 ```yaml
 # This example uses python, nodejs and ruby plugins:
-
 - asdf:
   - plugin: python
   - plugin: nodejs
   - plugin: ruby
 ```
 
-You can even install desired versions of languages and the global version:
+### Setting Default Versions
+
+With asdf 0.16.0+, you can set default versions using either the `default` parameter (recommended) or the legacy `global` parameter:
 
 ```yaml
 # This example installs python 3.7.4, nodejs 12.10 and ruby 2.6.4:
-
 - asdf:
   - plugin: python
     url: https://github.com/tuvistavie/asdf-python.git
-    global: 3.7.4
+    default: 3.7.4  # For asdf 0.16.0+ (recommended)
     versions:
       - 3.7.4
   - plugin: nodejs
     url: https://github.com/asdf-vm/asdf-nodejs.git
-    global: 12.10
+    global: 12.10  # Legacy syntax, still supported for backward compatibility
     versions:
       - 12.10
   - plugin: ruby
     url: https://github.com/asdf-vm/asdf-ruby.git
-    global: 2.6.4
+    default: 2.6.4
     versions:
       - 2.6.4
 ```
 
+### Advanced Configuration (asdf 0.16.0+)
+
+You can also set versions in the current directory or parent directories:
+
+```yaml
+- asdf:
+  - plugin: python
+    url: https://github.com/tuvistavie/asdf-python.git
+    versions:
+      - 3.10.4
+      - 3.11.0
+    default: 3.10.4  # Set in home directory (replaces global)
+    local: 3.11.0    # Set in current directory
+  - plugin: nodejs
+    url: https://github.com/asdf-vm/asdf-nodejs.git
+    versions:
+      - lts-hydrogen
+    parent:  # Set in parent directory
+      version: lts-hydrogen
+```
+
+### ASDF Location Configuration
+
 It's also possible to configure the location for asdf in case asdf itself was
 installed as part of the dotbot install process. This will cause the plugin to
 source the provided script before every asdf command.
-
 Only the first instance of `asdf_path` in the configuration will be respected.
 
 ```yaml
 - asdf:
   - asdf_path: /opt/asdf-vm/asdf.sh
   - plugin: python
-    global: 3.10.4
+    default: 3.10.4
     versions:
       - 3.10.4
 ```
 
-That's it!
+## ASDF 0.16.0+ Compatibility
+
+This plugin is fully compatible with asdf 0.16.0+ and supports the new command structure:
+
+- The deprecated `asdf global` command has been replaced with `asdf set --home`
+- The plugin supports both the older `global` parameter and the newer `default` parameter for backward compatibility
+- New features like setting versions in parent directories (`parent.version`) are supported
+
+For more information on asdf 0.16.0+ changes, see the [asdf upgrade guide](https://asdf-vm.com/guide/upgrading-to-v0.16.html).
 
 ## License
 


### PR DESCRIPTION
Hey @sobolevn, with the latest updates to asdf, I'm proposing some updates to the plugin to fix the breaking changes. There is still backwards compatibility with `global` as before. Please let me know if you agree/disagree with these changes. Made updates to the README as well. Happy to edit or adjust as needed. Thank you. 

Per these updates -[asdf - Upgrading to 0.16.0](https://asdf-vm.com/guide/upgrading-to-v0-16.html#breaking-changes)

```
Breaking Changes
Hyphenated commands have been removed
asdf version 0.15.0 and earlier supported by hyphenated and non-hyphenated versions of certain commands. With version 0.16.0 only the non-hyphenated versions are supported. The affected commands:

asdf list-all -> asdf list all
asdf plugin-add -> asdf plugin add
asdf plugin-list -> asdf plugin list
asdf plugin-list-all -> asdf plugin list all
asdf plugin-update -> asdf plugin update
asdf plugin-remove -> asdf plugin remove
asdf plugin-test -> asdf plugin test
asdf shim-versions -> asdf shimversions
asdf global and asdf local commands have been replaced with asdf set
asdf global and asdf local have been removed. The "global" and "local" terminology was wrong and also misleading. asdf doesn't actually support "global" versions that apply everywhere. Any version that was specified with asdf global could easily be overridden by a .tool-versions file in your current directory specifying a different version. This was confusing to users. The new asdf set behaves the same as asdf local by default, but also has flags for setting versions in the user's home directory (--home) and in an existing .tool-versions file in one of the parent directories (--parent). This new interface will hopefully convey a better understanding of how asdf resolves versions and provide equivalent functionality.

asdf update command has been removed
Updates can no longer be performed this way. Use your OS package manager or download the latest binary manually. Additionally, the asdf update command present in versions 0.15.0 and older cannot upgrade to version 0.16.0 because the install process has changed. You cannot upgrade to the latest Go implementation using asdf update.

asdf shell command has been removed
This command actually set an environment variable in the user's current shell session. It was able to do this because asdf was actually a shell function, not an executable. The new rewrite removes all shell code from asdf, and it is now a binary rather than a shell function, so setting environment variables directly in the shell is no longer possible.

asdf current has changed
Instead of three columns in the output, with the last being either the location the version is set or a suggested command that could be run to set or install a version. The third column has been split into two columns. The third column now only indicates the source of the version if it is set (typically either version file or environment variable) and the fourth is a boolean indicating whether the specified version is actually installed. If it is not installed, a suggested install command is shown.

Plugin extension commands must now be prefixed with cmd
Previously plugin extension commands could be run like this:

asdf nodejs nodebuild --version
Now they must be prefixed with cmd to avoid causing confusion with built-in commands:

asdf cmd nodejs nodebuild --version
```